### PR TITLE
Benchmark for CUDA kernels

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 80
 ignore = E741, W503, E231, E203, E266
-exclude = main.py, utils.py, models.py # TODO: Will address these after merging
+exclude = main.py, utils.py, models.py, .venv # TODO: Will address these after merging

--- a/scripts/benchmarks_v2.py
+++ b/scripts/benchmarks_v2.py
@@ -13,7 +13,7 @@ import os
 import pathlib
 import gc
 
-from condensed_sparsity.v2.condensed_linear import (  # noqa
+from condensed_sparsity.condensed_linear import (  # noqa
     CSRLinear,
     CondensedLinearStructured,
     CondensedLinearFineGrained,
@@ -430,7 +430,6 @@ def get_mod(
             ],
         )
     dotenv.load_dotenv("../.env", override=True)
-    os.environ["IMAGE_NET_PATH"]
     checkpoint_dir = pathlib.Path(f"./artifacts/checkpoints/{run_id}")
     checkpoint = Checkpoint.load_best_checkpoint(checkpoint_dir=checkpoint_dir)
     model_state = checkpoint.model

--- a/scripts/benchmarks_v2.py
+++ b/scripts/benchmarks_v2.py
@@ -9,7 +9,8 @@ from hydra import initialize, compose
 from rigl_torch.models import ModelFactory
 from rigl_torch.utils.checkpoint import Checkpoint
 import dotenv
-import os
+
+# import os
 import pathlib
 import gc
 
@@ -59,8 +60,20 @@ def main(
         cl_struc = CondensedLinearStructured(deepcopy(mod), dtype=dtype).eval()
         cl_fine = CondensedLinearFineGrained(deepcopy(mod), dtype=dtype).eval()
         cl_vmap = VmapCondensed(deepcopy(mod), dtype=dtype).eval()
-        ffi = FixedFanInCuda(deepcopy(mod), dtype=dtype, transpose=False, vectorize=True, index_dtype=torch.int16).eval()
-        ffi_tp = FixedFanInCuda(deepcopy(mod), dtype=dtype, transpose=True, vectorize=True, index_dtype=torch.int16).eval()
+        ffi = FixedFanInCuda(
+            deepcopy(mod),
+            dtype=dtype,
+            transpose=False,
+            vectorize=True,
+            index_dtype=torch.int16,
+        ).eval()
+        ffi_tp = FixedFanInCuda(
+            deepcopy(mod),
+            dtype=dtype,
+            transpose=True,
+            vectorize=True,
+            index_dtype=torch.int16,
+        ).eval()
         if include_csr:
             cl_sparse_op = CondensedLinearFineGrainedSparseOp(
                 deepcopy(mod), dtype=dtype
@@ -316,7 +329,12 @@ def main(
                             benchmark.Timer(
                                 stmt="ffi_tp(x)",
                                 setup="",
-                                globals={"x": x.transpose(0, 1).contiguous().transpose(0, 1), "ffi_tp": ffi_tp},
+                                globals={
+                                    "x": x.transpose(0, 1)
+                                    .contiguous()
+                                    .transpose(0, 1),
+                                    "ffi_tp": ffi_tp,
+                                },  # noqa
                                 label=label,
                                 sub_label=sub_label,
                                 description=("FFI TP (self)"),

--- a/src/condensed_sparsity/condensed_linear.py
+++ b/src/condensed_sparsity/condensed_linear.py
@@ -215,6 +215,58 @@ class CondensedLinearFineGrained(nn.Module):
         )
 
 
+class FixedFanInCuda(nn.Module):
+    def __init__(
+            self, module: nn.Module, dtype: torch.typename = torch.float32,
+            transpose: bool = True, vectorize: bool = False, index_dtype: torch.typename = torch.int32
+    ):
+        super().__init__()
+        if dtype is None:
+            dtype = module.weight.dtype
+
+        self.transpose = transpose
+        with torch.no_grad():
+            active_neuron_idx = module.weight.sum(dim=1) != 0
+            fine_grained_idx = (module.weight[active_neuron_idx] != 0).to(
+                torch.bool
+            )
+            _, self.input_mask = fine_grained_idx.nonzero(as_tuple=True)
+            self.input_mask = self.input_mask.reshape(
+                shape=(module.weight[active_neuron_idx].shape[0], -1)
+            ).to(index_dtype)
+            weight = module.weight[active_neuron_idx].detach().type(dtype)
+            weight = torch.clone(
+                weight[fine_grained_idx]
+                .reshape(shape=(weight.shape[0], -1))
+                .detach()
+                .type(dtype)
+            )
+            # padding to multiple of 4
+            if vectorize:
+                pad = (self.input_mask.shape[1] + 3) // 4 * 4 - self.input_mask.shape[1]
+                self.input_mask = F.pad(self.input_mask, [0, pad])
+                weight = F.pad(weight, [0, pad])
+
+            self.condensed_weight = nn.Parameter(
+                weight,
+                requires_grad=False,
+            )
+
+            if hasattr(module, "bias"):
+                self.bias = nn.Parameter(
+                    torch.clone(
+                        module.bias[active_neuron_idx].detach().type(dtype)
+                    ),
+                    requires_grad=False,
+                )
+            else:
+                self.register_parameter("bias", None)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        from torch_sparse.ops import ffi_mul
+        return ffi_mul(input, self.condensed_weight, self.input_mask, self.bias, transpose=self.transpose)
+
+
 class CondensedLinearFineGrainedSparseOp(nn.Module):
     def __init__(
         self, module: nn.Module, dtype: torch.typename = torch.float32

--- a/src/condensed_sparsity/condensed_linear.py
+++ b/src/condensed_sparsity/condensed_linear.py
@@ -217,8 +217,12 @@ class CondensedLinearFineGrained(nn.Module):
 
 class FixedFanInCuda(nn.Module):
     def __init__(
-            self, module: nn.Module, dtype: torch.typename = torch.float32,
-            transpose: bool = True, vectorize: bool = False, index_dtype: torch.typename = torch.int32
+        self,
+        module: nn.Module,
+        dtype: torch.typename = torch.float32,
+        transpose: bool = True,
+        vectorize: bool = False,
+        index_dtype: torch.typename = torch.int32,
     ):
         super().__init__()
         if dtype is None:
@@ -243,7 +247,9 @@ class FixedFanInCuda(nn.Module):
             )
             # padding to multiple of 4
             if vectorize:
-                pad = (self.input_mask.shape[1] + 3) // 4 * 4 - self.input_mask.shape[1]
+                pad = (
+                    self.input_mask.shape[1] + 3
+                ) // 4 * 4 - self.input_mask.shape[1]
                 self.input_mask = F.pad(self.input_mask, [0, pad])
                 weight = F.pad(weight, [0, pad])
 
@@ -263,8 +269,16 @@ class FixedFanInCuda(nn.Module):
                 self.register_parameter("bias", None)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        # TODO: move to header and add cuda kernel to build
         from torch_sparse.ops import ffi_mul
-        return ffi_mul(input, self.condensed_weight, self.input_mask, self.bias, transpose=self.transpose)
+
+        return ffi_mul(
+            input,
+            self.condensed_weight,
+            self.input_mask,
+            self.bias,
+            transpose=self.transpose,
+        )
 
 
 class CondensedLinearFineGrainedSparseOp(nn.Module):


### PR DESCRIPTION
This  doesn't actually do any useful measurements for the new kernels yet, as nothing is run on the GPU here, but I think just adding  GPU as a second option in the inner loop is also not a good idea, because then it'd run the gpu benchmarks for all the different number-of-threads settings, which probably doesn't make much sense.